### PR TITLE
feat: add typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "module": "dist/sveltemarkdown.es.js",
   "jsnext:main": "dist/sveltemarkdown.es.js",
   "svelte": "src/index.js",
-  "files": ["dist", "src"],
+  "files": [
+    "dist",
+    "src"
+  ],
   "license": "MIT",
   "repository": "github:pablo-abc/svelte-markdown",
   "homepage": "https://github.com/pablo-abc/svelte-markdown",
@@ -38,18 +41,25 @@
     "svelte-jester": "^1.3.0"
   },
   "dependencies": {
+    "@types/marked": "^2.0.0",
     "marked": "^2.0.0"
   },
   "peerDependencies": {
     "svelte": "^3.0.0"
   },
+  "types": "./types/index.d.ts",
   "jest": {
     "transform": {
       "^.+\\.js$": "babel-jest",
       "^.+\\.svelte$": "svelte-jester"
     },
-    "setupFilesAfterEnv": ["@testing-library/jest-dom/extend-expect"],
-    "moduleFileExtensions": ["js", "svelte"],
+    "setupFilesAfterEnv": [
+      "@testing-library/jest-dom/extend-expect"
+    ],
+    "moduleFileExtensions": [
+      "js",
+      "svelte"
+    ],
     "moduleNameMapper": {
       "marked/lib/marked.esm.js": "marked"
     }

--- a/src/markdown-parser.js
+++ b/src/markdown-parser.js
@@ -1,4 +1,3 @@
-import marked from 'marked/lib/marked.esm.js'
 import {
   Heading,
   Paragraph,
@@ -66,4 +65,4 @@ export const defaultOptions = {
   xhtml: false,
 }
 
-export const Lexer = marked.Lexer
+export { default as Lexer } from 'marked/src/Lexer'

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,41 +3,57 @@ import type { SvelteComponentTyped } from 'svelte'
 
 type MarkedRendererProps<
   T extends { type: string; raw: string; text?: string }
-> = Omit<T, 'type'>
+> = Partial<Omit<T, 'type'>>
+
+type InstantiableSvelteComponentTyped<
+  Props extends Record<string, any> = any,
+  Events extends Record<string, any> = any,
+  Slots extends Record<string, any> = any
+> = new (...args: any[]) => SvelteComponentTyped<Props, Events, Slots>
 
 type Renderers = {
-  text: SvelteComponentTyped<MarkedRendererProps<Tokens.Text>>
-  paragraph: SvelteComponentTyped<MarkedRendererProps<Tokens.Paragraph>>
-  em: SvelteComponentTyped<Omit<Tokens.Em, 'type' | 'text'>>
-  strong: SvelteComponentTyped<MarkedRendererProps<Tokens.Strong>>
-  hr: SvelteComponentTyped<MarkedRendererProps<Tokens.Hr>>
-  blockquote: SvelteComponentTyped<MarkedRendererProps<Tokens.Blockquote>>
-  del: SvelteComponentTyped<MarkedRendererProps<Tokens.Del>>
-  link: SvelteComponentTyped<MarkedRendererProps<Tokens.Link>>
-  image: SvelteComponentTyped<MarkedRendererProps<Tokens.Image>>
-  table: SvelteComponentTyped<{}>
-  tablehead: SvelteComponentTyped<{}>
-  tablebody: SvelteComponentTyped<{}>
-  tablerow: SvelteComponentTyped<{}>
-  tablecell: SvelteComponentTyped<{}>
-  list: SvelteComponentTyped<MarkedRendererProps<Tokens.List>>
+  text: InstantiableSvelteComponentTyped<MarkedRendererProps<Tokens.Text>>
+  paragraph: InstantiableSvelteComponentTyped<
+    MarkedRendererProps<Tokens.Paragraph>
+  >
+  em: InstantiableSvelteComponentTyped<Omit<Tokens.Em, 'type' | 'text'>>
+  strong: InstantiableSvelteComponentTyped<MarkedRendererProps<Tokens.Strong>>
+  hr: InstantiableSvelteComponentTyped<MarkedRendererProps<Tokens.Hr>>
+  blockquote: InstantiableSvelteComponentTyped<
+    MarkedRendererProps<Tokens.Blockquote>
+  >
+  del: InstantiableSvelteComponentTyped<MarkedRendererProps<Tokens.Del>>
+  link: InstantiableSvelteComponentTyped<MarkedRendererProps<Tokens.Link>>
+  image: InstantiableSvelteComponentTyped<MarkedRendererProps<Tokens.Image>>
+  table: InstantiableSvelteComponentTyped<{}>
+  tablehead: InstantiableSvelteComponentTyped<{}>
+  tablebody: InstantiableSvelteComponentTyped<{}>
+  tablerow: InstantiableSvelteComponentTyped<{}>
+  tablecell: InstantiableSvelteComponentTyped<{}>
+  list: InstantiableSvelteComponentTyped<MarkedRendererProps<Tokens.List>>
 
   // Technically, listItem includes {type: string, tokens: []} in the props,
   // but that's probably unintentional
-  listitem: SvelteComponentTyped<MarkedRendererProps<Tokens.ListItem>>
-  heading: SvelteComponentTyped<MarkedRendererProps<Tokens.Heading>>
-  codespan: SvelteComponentTyped<MarkedRendererProps<Tokens.Codespan>>
-  code: SvelteComponentTyped<MarkedRendererProps<Tokens.Code>>
+  listitem: InstantiableSvelteComponentTyped<
+    MarkedRendererProps<Tokens.ListItem>
+  >
+  heading: InstantiableSvelteComponentTyped<MarkedRendererProps<Tokens.Heading>>
+  codespan: InstantiableSvelteComponentTyped<
+    MarkedRendererProps<Tokens.Codespan>
+  >
+  code: InstantiableSvelteComponentTyped<MarkedRendererProps<Tokens.Code>>
 
   // Note there's some weird behaviour involved with this ATM.
   /**
-   * If the html is an inline element, it *should* be a Tag token (e.g `span`, `a`)
-   * If it's a block element, it *should* be an HTML token (e.g `div`, `p`).
+   * If the html is an inline element, it *should* be a Tag token (e.g `span`, `a`) If it's a
+   * block element, it *should* be an HTML token (e.g `div`, `p`).
    *
    * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Block-level_elements#elements}
    * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements#elements}
    */
-  html: SvelteComponentTyped<MarkedRendererProps<Tokens.HTML | Tokens.Tag>>
+  html: InstantiableSvelteComponentTyped<
+    MarkedRendererProps<Tokens.HTML | Tokens.Tag>
+  >
 }
 
 type Props = {
@@ -47,9 +63,8 @@ type Props = {
   source: string
 
   /**
-   * An object where the keys represent a node type and the value is a Svelte
-   * component.
-   * This object will be merged with the default renderers.
+   * An object where the keys represent a node type and the value is a Svelte component. This
+   * object will be merged with the default renderers.
    */
   renderers?: Partial<Renderers>
 
@@ -59,6 +74,8 @@ type Props = {
   options?: MarkedConfig
 }
 
-declare const SvelteMarkdown: SvelteComponentTyped<Props>
-
-export default SvelteMarkdown
+export default class SvelteMarkdown extends SvelteComponentTyped<
+  Props,
+  {},
+  { default: {} }
+> {}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,64 @@
+import type { MarkedExtension as MarkedConfig, Tokens } from 'marked'
+import type { SvelteComponentTyped } from 'svelte'
+
+export type MarkedRendererProps<
+  T extends { type: string; raw: string; text?: string }
+> = Omit<T, 'type'>
+
+type Renderers = {
+  text: SvelteComponentTyped<MarkedRendererProps<Tokens.Text>>
+  paragraph: SvelteComponentTyped<MarkedRendererProps<Tokens.Paragraph>>
+  em: SvelteComponentTyped<Omit<Tokens.Em, 'type' | 'text'>>
+  strong: SvelteComponentTyped<MarkedRendererProps<Tokens.Strong>>
+  hr: SvelteComponentTyped<MarkedRendererProps<Tokens.Hr>>
+  blockquote: SvelteComponentTyped<MarkedRendererProps<Tokens.Blockquote>>
+  del: SvelteComponentTyped<MarkedRendererProps<Tokens.Del>>
+  link: SvelteComponentTyped<MarkedRendererProps<Tokens.Link>>
+  image: SvelteComponentTyped<MarkedRendererProps<Tokens.Image>>
+  table: SvelteComponentTyped<{}>
+  tablehead: SvelteComponentTyped<{}>
+  tablebody: SvelteComponentTyped<{}>
+  tablerow: SvelteComponentTyped<{}>
+  tablecell: SvelteComponentTyped<{}>
+  list: SvelteComponentTyped<MarkedRendererProps<Tokens.List>>
+
+  // Technically, listItem includes {type: string, tokens: []} in the props,
+  // but that's probably unintentional
+  listitem: SvelteComponentTyped<MarkedRendererProps<Tokens.ListItem>>
+  heading: SvelteComponentTyped<MarkedRendererProps<Tokens.Heading>>
+  codespan: SvelteComponentTyped<MarkedRendererProps<Tokens.Codespan>>
+  code: SvelteComponentTyped<MarkedRendererProps<Tokens.Code>>
+
+  // Note there's some weird behaviour involved with this ATM.
+  /**
+   * If the html is an inline element, it *should* be a Tag token (e.g `span`, `a`)
+   * If it's a block element, it *should* be an HTML token (e.g `div`, `p`).
+   *
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Block-level_elements#elements}
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements#elements}
+   */
+  html: SvelteComponentTyped<MarkedRendererProps<Tokens.HTML | Tokens.Tag>>
+}
+
+type Props = {
+  /**
+   * The Markdown source to be parsed.
+   */
+  source: string
+
+  /**
+   * An object where the keys represent a node type and the value is a Svelte
+   * component.
+   * This object will be merged with the default renderers.
+   */
+  renderers?: Partial<Renderers>
+
+  /**
+   * Options for [marked](https://marked.js.org/using_advanced#options)
+   */
+  options?: MarkedConfig
+}
+
+declare const SvelteMarkdown: SvelteComponentTyped<Props>
+
+export default SvelteMarkdown

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 import type { MarkedExtension as MarkedConfig, Tokens } from 'marked'
 import type { SvelteComponentTyped } from 'svelte'
 
-export type MarkedRendererProps<
+type MarkedRendererProps<
   T extends { type: string; raw: string; text?: string }
 > = Omit<T, 'type'>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1219,6 +1219,11 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
+"@types/marked@^2.0.0":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-2.0.3.tgz#c8ea93684e530cc3b667d3e7226556dd0844ad1f"
+  integrity sha512-lbhSN1rht/tQ+dSWxawCzGgTfxe9DB31iLgiT1ZVT5lshpam/nyOA1m3tKHRoNPctB2ukSL22JZI5Fr+WI/zYg==
+
 "@types/node@*":
   version "14.14.28"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.28.tgz#cade4b64f8438f588951a6b35843ce536853f25b"


### PR DESCRIPTION
Adds typescript definitions

As for 9a7cef2, the library currently imports the entirety of marked because the marked esmodule library doesn't support tree shaking. This small change brought the bundle size from 66kb to 57kb.