### PR TITLE
chore: update marked to 4.0.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "svelte-jester": "^1.3.0"
   },
   "dependencies": {
-    "@types/marked": "^2.0.0",
-    "marked": "^2.0.0"
+    "@types/marked": "^4.0.1",
+    "marked": "^4.0.7"
   },
   "peerDependencies": {
     "svelte": "^3.0.0"

--- a/src/Parser.svelte
+++ b/src/Parser.svelte
@@ -1,6 +1,8 @@
 <script>
   export let type = undefined
   export let tokens = undefined
+  export let header = undefined
+  export let rows = undefined
   export let ordered = false
   export let renderers
 </script>
@@ -15,19 +17,19 @@
       <svelte:component this={renderers.table}>
         <svelte:component this={renderers.tablehead}>
           <svelte:component this={renderers.tablerow}>
-            {#each tokens.header as cells, i}
+            {#each header as headerItem, i}
               <svelte:component
                 this={renderers.tablecell}
                 header={true}
                 align={$$restProps.align[i] || 'center'}
                 >
-                <svelte:self tokens={cells} {renderers} />
+                <svelte:self tokens={headerItem.tokens} {renderers} />
               </svelte:component>
             {/each}
           </svelte:component>
         </svelte:component>
         <svelte:component this={renderers.tablebody}>
-          {#each tokens.cells as row}
+          {#each rows as row}
             <svelte:component this={renderers.tablerow}>
               {#each row as cells, i}
                 <svelte:component
@@ -35,7 +37,7 @@
                   header={false}
                   align={$$restProps.align[i] || 'center'}
                   >
-                  <svelte:self tokens={cells} {renderers} />
+                  <svelte:self tokens={cells.tokens} {renderers} />
                 </svelte:component>
               {/each}
             </svelte:component>

--- a/src/markdown-parser.js
+++ b/src/markdown-parser.js
@@ -1,4 +1,5 @@
-import marked from 'marked/lib/marked.esm.js'
+export { Lexer, Slugger } from 'marked'
+
 import {
   Heading,
   Paragraph,
@@ -67,6 +68,3 @@ export const defaultOptions = {
   tokenizer: null,
   xhtml: false,
 }
-
-export const Lexer = marked.Lexer
-export const Slugger = marked.Slugger

--- a/yarn.lock
+++ b/yarn.lock
@@ -1219,10 +1219,10 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
-"@types/marked@^2.0.0":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-2.0.3.tgz#c8ea93684e530cc3b667d3e7226556dd0844ad1f"
-  integrity sha512-lbhSN1rht/tQ+dSWxawCzGgTfxe9DB31iLgiT1ZVT5lshpam/nyOA1m3tKHRoNPctB2ukSL22JZI5Fr+WI/zYg==
+"@types/marked@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-4.0.1.tgz#d588a7bbc4d6551c5e75249bc106ffda96ae33c5"
+  integrity sha512-ZigEmCWdNUU7IjZEuQ/iaimYdDHWHfTe3kg8ORfKjyGYd9RWumPoOJRQXB0bO+XLkNwzCthW3wUIQtANaEZ1ag==
 
 "@types/node@*":
   version "14.14.28"
@@ -3568,10 +3568,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-2.0.0.tgz#9662bbcb77ebbded0662a7be66ff929a8611cee5"
-  integrity sha512-NqRSh2+LlN2NInpqTQnS614Y/3NkVMFFU6sJlRFEpxJ/LHuK/qJECH7/fXZjk4VZstPW/Pevjil/VtSONsLc7Q==
+marked@^4.0.7:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.7.tgz#596a0826e7a8c6b4119eacd00b0220ddaee7fc71"
+  integrity sha512-mQrRvV2vRk7DHZsWsYJfAjmBo+lSYPhTJPThaaGpkEfmC+4oefeug2txZniQTieDS0CFpokfVhd7JuS5GtnHhA==
 
 maxmin@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
I was having trouble installing `svelte-markdown` with pnpm, and it was due to the old `marked` dependency version. So I updated the dependency to the latest version.

Table parsing had a breaking change, so I had to modify that part. Maybe the variable names could be improved. See here for the relevant changelog: https://github.com/markedjs/marked/releases/tag/v3.0.0

Also had to change the way `Lexer` and `Slugger` are imported/exported from. `marked`. Not sure if there's an issue with this way of doing it, but it seems to work well.

Tests are passing, and I also tested it in my own website which reads GitHub markdown from a bunch of repos. All of the ones listed [here](https://outerwildsmods.com/mods/) seem to be working fine (that url isn't currently using svelte-markdown, but I tested locally with the same samples).