### PR TITLE
feat: add extensions support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The SvelteMarkdown component accepts the following options:
 - `source` - _string_ The Markdown source to be parsed.
 - `renderers` - _object (optional)_ An object where the keys represent a node type and the value is a Svelte component. This object will be merged with the default renderers. For now you can check how the default renderers are written in the source code at `src/renderers`.
 - `options` - _object (optional)_ An object containing [options for Marked](https://marked.js.org/using_advanced#options)
+- `use` - _object (optional)_ An object containing [extensions for Marked]([marked.use](https://marked.js.org/using_pro#use)) 
 
 ## Events
 

--- a/src/SvelteMarkdown.svelte
+++ b/src/SvelteMarkdown.svelte
@@ -1,13 +1,14 @@
 <script>
   import { setContext, createEventDispatcher, onMount } from 'svelte'
   import Parser from './Parser.svelte'
-  import { Lexer, Slugger, defaultOptions, defaultRenderers } from './markdown-parser'
+  import { Lexer, Slugger, defaultOptions, defaultRenderers, marked } from './markdown-parser'
   import { key } from './context'
 
   export let source = ''
   export let renderers = {}
   export let options = {}
   export let isInline = false
+  export let use = {}
 
   const dispatch = createEventDispatcher();
 
@@ -18,7 +19,10 @@
   $: slugger = source ? new Slugger : undefined
   $: combinedOptions = { ...defaultOptions, ...options }
   $: {
-    lexer = new Lexer(combinedOptions)
+    marked.setOptions(combinedOptions)
+    marked.use(use)
+
+    lexer = new Lexer()
 
     tokens = isInline ? lexer.inlineTokens(source) : lexer.lex(source)
 

--- a/src/markdown-parser.js
+++ b/src/markdown-parser.js
@@ -1,4 +1,4 @@
-export { Lexer, Slugger } from 'marked'
+export { Lexer, Slugger, marked } from 'marked'
 
 import {
   Heading,

--- a/tests/TestRenderer.svelte
+++ b/tests/TestRenderer.svelte
@@ -1,0 +1,6 @@
+<script>
+  export let value = 0
+  export let message = ''
+</script>
+
+<span>{message}: {value}</span>

--- a/tests/extensions.spec.js
+++ b/tests/extensions.spec.js
@@ -18,19 +18,14 @@ describe('testing extensions', () => {
         return src.match(/\[\[/).index
       },
       tokenizer(src) {
-        const rule = /^\[\[test\s+([^\]]*)\]\]/
+        const rule = /^\[\[test(?:(?=.*?\svalue="(.*?)".*?|.*)(?=.*?\smessage="(.*?)(?<!\\)".*?|.*).*?|\s*)\]\]/
         const match = rule.exec(src)
         if (match) {
-          const options = match[1]
-          const valueRule = /value="([^"]*)"/
-          const messageRule = /message="([^"]*)"/
-          const value = valueRule.exec(options)
-          const message = messageRule.exec(options)
           return {
             type: 'test',
             raw: match[0],
-            value: value ? value[1] : undefined,
-            message: message ? message[1] : undefined,
+            value: match[1],
+            message: match[2],
           }
         }
       },

--- a/tests/extensions.spec.js
+++ b/tests/extensions.spec.js
@@ -1,0 +1,49 @@
+import '@testing-library/jest-dom/extend-expect'
+
+import { render, screen } from '@testing-library/svelte'
+
+import SvelteMarkdown from '../src/SvelteMarkdown.svelte'
+import TestRenderer from './TestRenderer.svelte'
+
+describe('testing extensions', () => {
+  beforeAll(() => {
+    console.warn = jest.fn()
+  })
+
+  test('renders a custom token with an extension and custom component', () => {
+    const testTokenizerExtension = {
+      name: 'test',
+      level: 'inline',
+      start(src) {
+        return src.match(/\[\[/).index
+      },
+      tokenizer(src) {
+        const rule = /^\[\[test\s+([^\]]*)\]\]/
+        const match = rule.exec(src)
+        if (match) {
+          const options = match[1]
+          const valueRule = /value="([^"]*)"/
+          const messageRule = /message="([^"]*)"/
+          const value = valueRule.exec(options)
+          const message = messageRule.exec(options)
+          return {
+            type: 'test',
+            raw: match[0],
+            value: value ? value[1] : undefined,
+            message: message ? message[1] : undefined,
+          }
+        }
+      },
+    }
+
+    render(SvelteMarkdown, {
+      source: '[[test value="5" message="test message"]]',
+      use: { extensions: [testTokenizerExtension] },
+      renderers: { test: TestRenderer },
+    })
+
+    const element = screen.getByText('test message', { exact: false })
+    expect(element).toBeInTheDocument()
+    expect(element).toContainHTML('<span>test message: 5</span>')
+  })
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -75,7 +75,7 @@ type Props = {
   /**
    * Parameters for the function [marked.use](https://marked.js.org/using_pro#use)
    */
-  use?: Parameters<typeof marked.use>
+  use?: Omit<marked.MarkedExtension, 'renderer'>[]
 
   /**
    * Options for [marked](https://marked.js.org/using_advanced#options)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,5 @@
 import type {
+  marked,
   MarkedExtension as MarkedConfig,
   Tokens,
   TokensList,
@@ -70,6 +71,11 @@ type Props = {
    * object will be merged with the default renderers.
    */
   renderers?: Partial<Renderers>
+
+  /**
+   * Parameters for the function [marked.use](https://marked.js.org/using_pro#use)
+   */
+  use?: Parameters<typeof marked.use>
 
   /**
    * Options for [marked](https://marked.js.org/using_advanced#options)


### PR DESCRIPTION
Quick and dirty: Add "use" parameter which allows extensions (see #17 ).

Example usage (replaces token `[[latex…]]` with a colored `span`):
File `App.svelte`
```svelte
<script>
  import SvelteMarkdown from "svelte-markdown";
  import LatexMarkdown from "./LatexMarkdown.svelte";

  const latexTokenizerExtension = {
    name: "latex",
    level: "inline",
    start(src) {
      return src.match(/\[\[/)?.index;
    },
    tokenizer(src, tokens) {
      const rule = /^\[\[latex\s*(?:color="(.*)")?\]\]/;
      const match = rule.exec(src);
      if (match) {
        console.log(match[1]);
        return {
          type: "latex",
          raw: match[0],
          text: match[0],
          color: match[1],
        };
      }
    },
  };

  const use = { extensions: [latexTokenizerExtension] };

  const renderers = {
    latex: LatexMarkdown,
  };

  const source = `
  # This is a header

This is a paragraph.

This is red [[latex color="red"]] text.

* This is a list
* With two items
  1. And a sublist
  2. That is ordered
    * With another
    * Sublist inside

| And this is | A table |
|-------------|---------|
| With two    | columns |`;
</script>

<SvelteMarkdown {source} {use} {renderers} />
```
Imported file `LatexMarkdown.svelte`
```svelte
<script>
  export let color;
</script>

<span style={"color: " + color}>LaTeX</span>
```