### PR TITLE
feat: support for walkTokens

### DIFF
--- a/src/SvelteMarkdown.svelte
+++ b/src/SvelteMarkdown.svelte
@@ -1,7 +1,7 @@
 <script>
   import { setContext, createEventDispatcher, onMount } from 'svelte'
   import Parser from './Parser.svelte'
-  import { Lexer, Slugger, defaultOptions, defaultRenderers } from './markdown-parser'
+  import { Lexer, Slugger, defaultOptions, defaultRenderers, marked } from './markdown-parser'
   import { key } from './context'
 
   export let source = ''
@@ -21,6 +21,10 @@
     lexer = new Lexer(combinedOptions)
 
     tokens = isInline ? lexer.inlineTokens(source) : lexer.lex(source)
+
+    if (combinedOptions.walkTokens) {
+      marked.walkTokens(tokens, combinedOptions.walkTokens)
+    }
 
     dispatch('parsed', { tokens })
   }

--- a/src/markdown-parser.js
+++ b/src/markdown-parser.js
@@ -1,4 +1,4 @@
-export { Lexer, Slugger } from 'marked'
+export { Lexer, Slugger, marked } from 'marked'
 
 import {
   Heading,


### PR DESCRIPTION
Currently `svelte-markdown` does not support [walkTokens](https://marked.js.org/using_pro#walk-tokens). 
This adds this feature (similar to the way [marked itself does it](https://github.com/markedjs/marked/blob/4c5b974b391f913ac923610bd3740ef27ccdae95/src/marked.js#L110)).