### PR TITLE
Only suppress warnings in Vite dev mode and on client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "svelte-markdown",
   "description": "A markdown renderer for Svelte",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "dist/sveltemarkdown.js",
   "module": "dist/sveltemarkdown.es.js",
   "jsnext:main": "dist/sveltemarkdown.es.js",

--- a/src/Parser.svelte
+++ b/src/Parser.svelte
@@ -8,7 +8,7 @@
   export let ordered = false
   export let renderers
 
-  supressWarnings();
+  supressWarnings(renderers);
 </script>
 
 {#if !type}

--- a/src/supress-warnings.js
+++ b/src/supress-warnings.js
@@ -1,15 +1,34 @@
 import { onMount } from 'svelte'
 
-export function supressWarnings() {
-  const origWarn = console.warn
+export function supressWarnings(renderers) {
+  // https://vitejs.dev/guide/env-and-mode.html
+  if (import.meta?.env?.DEV === false) return; // we're suppressing warnings that are only shown in dev mode
 
-  console.warn = (message) => {
-    if (message.includes('unknown prop')) return
-    if (message.includes('unexpected slot')) return
-    origWarn(message)
-  }
+  const isBrowser = typeof window !== "undefined" && typeof window.document !== "undefined";
+  if (!isBrowser) return; // we don't want to change anything on the server, especially, because we only undo the change on the client (in onMount)
+
+  const markdownComponentNames = Object.values(renderers)
+    .map(r => r?.name)
+    .filter(r => !!r)
+    .join('|');
+
+  const unknownPropsRegex = new RegExp(`<(${markdownComponentNames})(_[\w$]+)?> was created (with unknown|without expected) prop`);
+  const unexpectedSlotRegex = new RegExp(`<(${markdownComponentNames})(_[\w$]+)?> received an unexpected slot ["']default["']`);
+
+  // Nasty hack to silence harmless warnings the user can do nothing about. SvelteKit does the same thing:
+  // https://github.com/sveltejs/kit/blob/976a8b80fb4fa9ac2e7938deb3ea248b2d54dfa1/packages/kit/src/runtime/client/client.js#L1557C1-L1571C2
+  const origWarn = console.warn;
+  console.warn = (...args) => {
+    if (
+      args.length === 1 &&
+      (unknownPropsRegex.test(args[0]) || unexpectedSlotRegex.test(args[0]))
+    ) {
+      return;
+    }
+    origWarn(...args);
+  };
 
   onMount(() => {
     console.warn = origWarn
-  })
+  });
 }


### PR DESCRIPTION
We can't use this package unless this fix gets merged.

As [I commented](https://github.com/pablo-abc/svelte-markdown/pull/63#issuecomment-1827693657), `suppressWarnings` currently kills our node server, which is pretty wild, because it only gets "uninstrumented" on the client, so the `console.warn` call stack just grows and grows.

This is an improvement to the currently open PR #63.

The warnings are only logged in dev mode, so we can leave `console.warn` alone if we know that we're not in dev mode.
And we certainly don't want to touch globals in node/on the server.

I did my best to determine dev mode and client without assuming we're running in a Vite app.
If the code is not running in a Vite app, then we can't detect dev mode, so it will behave the same in the browser as it did before.
Except that I made the filter a bit smarter, so that it should only suppress warnings that are actually caused by markdown renderers.