### PR TITLE
chore: Use "exports" condition in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "module": "dist/sveltemarkdown.es.js",
   "jsnext:main": "dist/sveltemarkdown.es.js",
   "svelte": "src/index.js",
+  "exports": {
+    ".": {
+      "svelte": "src/index.js"
+    }
+  },
   "type": "module",
   "files": [
     "dist",


### PR DESCRIPTION
Per the [`vite-plugin-svelte` docs](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition), all Svelte libraries should use the `exports` option in `package.json` instead of `svelte`, which is deprecated and will be removed soon.

Warning message from Svelte that showed this issue:

![Screenshot 2023-12-14 at 1 34 05 PM](https://github.com/pablo-abc/svelte-markdown/assets/4662240/e2462b0f-001a-47ff-a0f6-9bd8a30072b8)
